### PR TITLE
problem: package import and not used

### DIFF
--- a/mindmachine/initConfig.go
+++ b/mindmachine/initConfig.go
@@ -1,7 +1,6 @@
 package mindmachine
 
 import (
-	"fmt"
 	"net/http"
 	"os"
 


### PR DESCRIPTION
qspang@LAPTOP-E94QJJKL:~/stackerstan/mindmachine$ make reset
cp -R ~/mindmachine/data/nostrelay ~/mindmachine/
rm -rf ~/mindmachine/data
mkdir ~/mindmachine/data
cp -R ~/mindmachine/nostrelay ~/mindmachine/data/
rm -rf ~/mindmachine/nostrelay
go mod tidy
go run cmd/mindmachine/*.go
# mindmachine/mindmachine
mindmachine/initConfig.go:4:2: imported and not used: "fmt"
make: *** [Makefile:39: reset] Error 2